### PR TITLE
[1.21.1] Minor fix for SnowRealMagic handler

### DIFF
--- a/src/main/java/bl4ckscor3/mod/snowundertrees/SnowUnderTrees.java
+++ b/src/main/java/bl4ckscor3/mod/snowundertrees/SnowUnderTrees.java
@@ -93,7 +93,7 @@ public class SnowUnderTrees {
 		if (biome.value().getPrecipitationAt(pos) == Precipitation.SNOW || isSereneSeasonsLoaded && SereneSeasonsHandler.coldEnoughToSnow(level, biome, pos)) {
 			BlockState stateAtPos = level.getBlockState(pos);
 
-			if (!stateAtPos.canBeReplaced())
+			if (!snowManager.canBeReplaced(stateAtPos))
 				return false;
 
 			if (temperatureCheck.apply(level, pos) && isInBuildRangeAndDarkEnough(level, pos)) {

--- a/src/main/java/bl4ckscor3/mod/snowundertrees/manager/SnowManager.java
+++ b/src/main/java/bl4ckscor3/mod/snowundertrees/manager/SnowManager.java
@@ -7,6 +7,8 @@ import net.minecraft.world.level.block.state.BlockState;
 public interface SnowManager {
 	public boolean placeSnow(WorldGenLevel level, BlockPos pos);
 
+	public boolean canBeReplaced(BlockState state);
+
 	public boolean isSnow(WorldGenLevel level, BlockPos pos);
 
 	public BlockState getStateAfterMelting(BlockState stateNow, WorldGenLevel level, BlockPos pos);

--- a/src/main/java/bl4ckscor3/mod/snowundertrees/manager/SnowRealMagicManager.java
+++ b/src/main/java/bl4ckscor3/mod/snowundertrees/manager/SnowRealMagicManager.java
@@ -20,6 +20,11 @@ public class SnowRealMagicManager implements SnowManager {
 	}
 
 	@Override
+	public boolean canBeReplaced(BlockState state) {
+		return state.canBeReplaced() || Hooks.canContainState(state);
+	}
+
+	@Override
 	public boolean isSnow(WorldGenLevel level, BlockPos pos) {
 		Block block = level.getBlockState(pos).getBlock();
 

--- a/src/main/java/bl4ckscor3/mod/snowundertrees/manager/VanillaManager.java
+++ b/src/main/java/bl4ckscor3/mod/snowundertrees/manager/VanillaManager.java
@@ -43,6 +43,11 @@ public class VanillaManager implements SnowManager {
 	}
 
 	@Override
+	public boolean canBeReplaced(BlockState state) {
+		return state.canBeReplaced();
+	}
+
+	@Override
 	public boolean isSnow(WorldGenLevel level, BlockPos pos) {
 		return level.getBlockState(pos).getBlock() == Blocks.SNOW;
 	}


### PR DESCRIPTION
This PR allows SnowUnderTrees to generate snow into any SnowRealMagic supported block, not just blocks that return true for `state.canBeReplaced()`. For example, now it can also generate into flowers and mushrooms.

---

Before:

<img width="1866" height="1052" alt="2026-06-14_10 44 56" src="https://github.com/user-attachments/assets/80f01740-956a-4d89-adac-1ed123ec71ec" />

After:

<img width="1866" height="1052" alt="2026-06-14_10 43 42" src="https://github.com/user-attachments/assets/b67b6888-7e57-4f98-a1de-107bdeab34ea" />

---

Coords: x=-266, z=233
Seed: 7944892377146807027